### PR TITLE
XERCESC-2190: Remove deprecated getVersionEx

### DIFF
--- a/src/xercesc/util/FileManagers/WindowsFileMgr.hpp
+++ b/src/xercesc/util/FileManagers/WindowsFileMgr.hpp
@@ -54,7 +54,6 @@ class WindowsFileMgr : public XMLFileMgr
         virtual bool		isRelative(const XMLCh* const toCheck, MemoryManager* const manager);
 
     private:
-        bool _onNT;
 };
 
 XERCES_CPP_NAMESPACE_END

--- a/src/xercesc/util/Transcoders/Win32/Win32TransService.cpp
+++ b/src/xercesc/util/Transcoders/Win32/Win32TransService.cpp
@@ -35,7 +35,7 @@
 #include <xercesc/util/XMLUni.hpp>
 #include <xercesc/util/RefHashTableOf.hpp>
 #include "Win32TransService.hpp"
-
+#include <versionhelpers.h>
 XERCES_CPP_NAMESPACE_BEGIN
 
 
@@ -317,15 +317,7 @@ Win32TransService::Win32TransService(MemoryManager* manager) :
 {
     // Figure out if we are on XP or later and save that flag for later use.
     // We need this because of certain code page conversion calls.
-    OSVERSIONINFO   OSVer;
-    OSVer.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-    ::GetVersionEx(&OSVer);
-
-    if ((OSVer.dwPlatformId == VER_PLATFORM_WIN32_NT) &&
-        (OSVer.dwMajorVersion > 5 || (OSVer.dwMajorVersion == 5 && OSVer.dwMinorVersion > 0)))
-    {
-        onXPOrLater = true;
-    }
+    onXPOrLater = IsWindowsXPOrGreater();
 
     fCPMap = new RefHashTableOf<CPMapEntry>(109);
 


### PR DESCRIPTION
`C:\Work\code\xerces-c\src\xercesc\util\Transcoders\Win32\Win32TransService.cpp(323): warning C4996: 'GetVersionExA': was declared deprecated
C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\um\sysinfoapi.h(387): note: see declaration of 'GetVersionExA'`

1. remove win9x support in WindowsFileMgr 
2. remove deprecated GetVersionEx in Win32TransService. You need VS2012+ or WinSDK 8.1 for build 