### PR TITLE
XERCESC-2200: Update AppVeyor for VS2017 and vcpkg

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,6 @@
 environment:
   AV_PROJECTS: 'c:\projects'
   AV_XERCES_DOWNLOAD: 'c:\projects\download'
-  AV_XERCES_TOOLS: 'c:\projects\tools'
   AV_XERCES_SOURCE: 'c:\projects\xerces-c'
   AV_XERCES_BUILD: 'c:\projects\build'
   AV_XERCES_INSTALL: 'c:/projects/libs'
@@ -75,9 +74,9 @@ environment:
       transcoder: iconv
       mutexmanager:
       xmlch: uint16_t
-    - compiler: vc14
+    - compiler: vc15
       configuration: Release
-      generator: Visual Studio 14 2015 Win64
+      generator: Visual Studio 15 2017 Win64
       shared: ON
       network: ON
       netaccessor:
@@ -86,9 +85,9 @@ environment:
       mutexmanager: windows
       xmlch: wchar_t
       mfc: ON
-    - compiler: vc14
+    - compiler: vc15
       configuration: Debug
-      generator: Visual Studio 14 2015 Win64
+      generator: Visual Studio 15 2017 Win64
       shared: OFF
       network: OFF
       netaccessor: winsock
@@ -98,8 +97,11 @@ environment:
       xmlch: char16_t
       mfc: OFF
 
+cache:
+  - 'c:\tools\vcpkg\installed -> scripts/ci-appveyor-setup'
+
 # Operating system (build VM template)
-os: 'Visual Studio 2015'
+os: 'Visual Studio 2017'
 
 # clone directory
 clone_folder: 'c:\projects\xerces-c'
@@ -112,19 +114,16 @@ init:
 
 before_build:
   - 'FOR /F "tokens=* USEBACKQ" %%F IN (`C:\cygwin64\bin\cygpath -u %AV_XERCES_DOWNLOAD%`) DO SET AV_XERCES_CYG_DOWNLOAD=%%F'
-  - 'FOR /F "tokens=* USEBACKQ" %%F IN (`C:\cygwin64\bin\cygpath -u %AV_XERCES_TOOLS%`) DO SET AV_XERCES_CYG_TOOLS=%%F'
   - 'FOR /F "tokens=* USEBACKQ" %%F IN (`C:\cygwin64\bin\cygpath -u %AV_XERCES_SOURCE%`) DO SET AV_XERCES_CYG_SOURCE=%%F'
   - 'FOR /F "tokens=* USEBACKQ" %%F IN (`C:\cygwin64\bin\cygpath -u %AV_XERCES_INSTALL%`) DO SET AV_XERCES_CYG_INSTALL=%%F'
   - 'if NOT EXIST "%AV_XERCES_DOWNLOAD%\" mkdir %AV_XERCES_DOWNLOAD%'
-  - 'if NOT EXIST "%AV_XERCES_TOOLS%\" mkdir %AV_XERCES_TOOLS%'
   - 'if %compiler%==cygwin C:\Cygwin64\setup-x86_64 -q -R C:\Cygwin64 -s http://cygwin.mirror.constant.com -l %AV_XERCES_DOWNLOAD%\cygwin -P libcurl-devel,cmake'
   - if [%msgloader%] == [icu] set AV_ICU_BUILD=true
   - if [%transcoder%] == [icu] set AV_ICU_BUILD=true
-  - 'if EXIST "%AV_PROJECTS%\icu" set AV_ICU_BUILD=false'
-  - 'set "PATH=C:\Program Files (x86)\cmake\bin;%AV_XERCES_TOOLS%;%PATH%"'
   - 'if %compiler%==cygwin set "PATH=C:\Cygwin64\bin;%PATH%"'
   - 'if %compiler%==mingw set "PATH=C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%"'
   - set "AV_CMAKE_ARGS=-DBUILD_SHARED_LIBS:BOOL=%shared%"
+  - 'if %compiler%==vc15 set "AV_CMAKE_ARGS=%AV_CMAKE_ARGS% -DCMAKE_TOOLCHAIN_FILE:PATH=C:\tools\vcpkg\scripts\buildsystems\vcpkg.cmake"'
   - set "AV_CMAKE_ARGS=%AV_CMAKE_ARGS% -Dnetwork:BOOL=%network%"
   - if NOT [%netaccessor%] == [] set "AV_CMAKE_ARGS=%AV_CMAKE_ARGS% -Dnetwork-accessor=%netaccessor%"
   - if NOT [%msgloader%] == [] set "AV_CMAKE_ARGS=%AV_CMAKE_ARGS% -Dmessage-loader=%msgloader%"
@@ -137,19 +136,11 @@ before_build:
   - 'if %compiler%==cygwin set "AV_XERCES_CMAKE_SOURCE=%AV_XERCES_CYG_SOURCE%'
   - 'if %compiler%==cygwin set "AV_XERCES_CMAKE_INSTALL=%AV_XERCES_CYG_INSTALL%'
   - 'C:\cygwin64\bin\bash %AV_XERCES_CYG_SOURCE%/scripts/ci-appveyor-setup'
-  - set ICU_PLATFORM=x64
-  - if [%platform%] == [x86] set ICU_PLATFORM=Win32
-  - 'if [%AV_ICU_BUILD%] == [true] cd "%AV_PROJECTS%\icu"'
-  - 'if [%AV_ICU_BUILD%] == [true] echo "Running msbuild to build ICU"'
-  - 'if [%AV_ICU_BUILD%] == [true] call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %platform%'
-  - 'if [%AV_ICU_BUILD%] == [true] msbuild source\allinone\allinone.sln /p:Configuration=%configuration% /p:Platform=%ICU_PLATFORM% /m'
-  - 'if [%AV_ICU_BUILD%] == [true] set "PATH=%AV_PROJECTS%\icu\bin;%AV_PROJECTS%\icu\bin64;%PATH%"'
-  - 'if [%AV_ICU_BUILD%] == [true] set "CMAKE_PREFIX_PATH=%AV_PROJECTS%\icu"'
   - mkdir %AV_XERCES_BUILD%
   - cd %AV_XERCES_BUILD%
   - echo Running cmake -G "%generator%" -DCMAKE_INSTALL_PREFIX=%AV_XERCES_CMAKE_INSTALL% -DCMAKE_BUILD_TYPE=%configuration% %AV_XERCES_CMAKE_SOURCE%
 
-  - cmake -G "%generator%" -DCMAKE_INSTALL_PREFIX=%AV_XERCES_CMAKE_INSTALL% -DCMAKE_BUILD_TYPE=%configuration% %AV_CMAKE_ARGS% %AV_XERCES_CMAKE_SOURCE%
+  - cmake -G "%generator%" -DCMAKE_INSTALL_PREFIX:PATH=%AV_XERCES_CMAKE_INSTALL% -DCMAKE_BUILD_TYPE=%configuration% %AV_CMAKE_ARGS% %AV_XERCES_CMAKE_SOURCE%
 
 build_script:
   - cd %AV_XERCES_BUILD%

--- a/scripts/ci-appveyor-setup
+++ b/scripts/ci-appveyor-setup
@@ -5,52 +5,11 @@ set -x
 
 PATH="/cygdrive/c/cygwin64/bin:$PATH"
 
-download_file()
-(
-    url="$1"
-    file="$2"
-    hash="$3"
-    hash_output="${hash} *$file"
-
-  if [ ! -f "$file" ]; then
-    echo "Downloading $file"
-  else
-    if [ "$(sha512sum "$file")" != "$hash_output" ]; then
-      echo "$file sha512sum mismatch"
-    fi
+if [ "$compiler" = "vc15" ]; then
+  if [ ! -f /cygdrive/c/tools/vcpkg/installed/x64-windows/bin/icuuc65.dll ]; then
+    cd "$(cygpath -u "c:\\tools\\vcpkg")"
+    git pull
+    ./bootstrap-vcpkg.bat
+    ./vcpkg install icu:x64-windows curl:x64-windows
   fi
-
-  if [ ! -f "$file" ] || [ "$(sha512sum "$file")" != "$hash_output" ]; then
-    rm -f "$file"
-    curl -L -o "$file" "$url"
-  fi
-  [ "$(sha512sum "$file")" = "$hash_output" ]
-)
-
-icu_source=icu4c-60_2-src.zip
-icu_url="http://download.icu-project.org/files/icu4c/60.2/${icu_source}"
-icu_hash="63232d6c15f725a60c14465b0479995b488b51288517e522abebdf5996fac7f214c424520bdbedb4c0801ea85ea7ad35de13e00512a25c1399cb827b0aca4744"
-
-ninja_binary="ninja-win.zip"
-ninja_url="https://github.com/ninja-build/ninja/releases/download/v1.8.2/${ninja_binary}"
-ninja_hash="9b9ce248240665fcd6404b989f3b3c27ed9682838225e6dc9b67b551774f251e4ff8a207504f941e7c811e7a8be1945e7bcb94472a335ef15e23a0200a32e6d5"
-
-
-if [ "$msgloader" = "icu" ] || [ "$transcoder" = icu ]; then
-    cd "$AV_XERCES_CYG_DOWNLOAD"
-    download_file "$icu_url" "$icu_source" "$icu_hash"
-fi
-
-if [ "$msgloader" = "icu" ] || [ "$transcoder" = icu ]; then
-    cd "$AV_PROJECTS"
-    rm -rf icu
-    7z x "${AV_XERCES_DOWNLOAD}\\$icu_source"
-fi
-
-if [ "$generator" = "Ninja" ]; then
-    cd "$AV_XERCES_CYG_DOWNLOAD"
-    download_file "$ninja_url" "$ninja_binary" "$ninja_hash"
-    cd "$AV_XERCES_CYG_TOOLS"
-    rm -f ninja
-    7z e "${AV_XERCES_DOWNLOAD}\\$ninja_binary"
 fi


### PR DESCRIPTION
* Use VS2017 image, which also updates MinGW, and adds CMake, Ninja and vcpkg.
* Build with VS2017
* Use vcpkg to build and install ICU and CURL
* Newer versions of MinGW are currently broken with Xerces-C++; XERCESC-2203 opened as a followup