### PR TITLE
XERCESC-2217: ICUTranscoder::transcodeFrom(): fix read heap-buffer-overflow

### DIFF
--- a/src/xercesc/util/Transcoders/ICU/ICUTransService.cpp
+++ b/src/xercesc/util/Transcoders/ICU/ICUTransService.cpp
@@ -563,7 +563,7 @@ ICUTranscoder::transcodeFrom(const  XMLByte* const          srcData
         {
             charSizes[0] = (unsigned char)bytesEaten;
         }
-        else
+        else if( charsDecoded > 0 )
         {
             //  ICU does not return an extra element to allow us to figure
             //  out the last char size, so we have to compute it from the
@@ -574,10 +574,9 @@ ICUTranscoder::transcodeFrom(const  XMLByte* const          srcData
                 charSizes[index] = (unsigned char)(fSrcOffsets[index + 1]
                                                     - fSrcOffsets[index]);
             }
-            if( charsDecoded > 0 ) {
-                charSizes[charsDecoded - 1] = (unsigned char)(bytesEaten
-                                              - fSrcOffsets[charsDecoded - 1]);
-            }
+
+            charSizes[charsDecoded - 1] = (unsigned char)(bytesEaten
+                                          - fSrcOffsets[charsDecoded - 1]);
         }
     }
 


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35373

When charsDecoded == 0, the line ``for (index = 0; index < charsDecoded- 1; index++)`` will cause to read out of bounds of fSrcOffsets, due to unsigned integer underflow rules.

Can be verified with the attached (broken) XML file: [test.gml.zip](https://github.com/apache/xerces-c/files/6960822/test.gml.zip)

This should be backported to the 3.2 branch