### PR TITLE
XERCESC-2218: CurlURLInputStream constructor: avoid memory leak

### DIFF
--- a/src/xercesc/util/NetAccessors/Curl/CurlURLInputStream.hpp
+++ b/src/xercesc/util/NetAccessors/Curl/CurlURLInputStream.hpp
@@ -61,6 +61,8 @@ private :
     CurlURLInputStream(const CurlURLInputStream&);
     CurlURLInputStream& operator=(const CurlURLInputStream&);
     
+    void cleanup();
+
     static size_t staticWriteCallback(char *buffer,
                                       size_t size,
                                       size_t nitems,


### PR DESCRIPTION
CurlURLInputStream constructor calls the readMore() method, which can
throw exceptions. In that situation, the destructor is not called, which
results in resource/memory leaks. To fix that, catch the exceptions,
manually do the cleanup and rethrow the exceptions.

Found by ossfuzz (locally)