### PR TITLE
Fix -Wmemset-transposed-args warnings of clang++

### DIFF
--- a/src/xercesc/util/XMLChTranscoder.cpp
+++ b/src/xercesc/util/XMLChTranscoder.cpp
@@ -70,7 +70,7 @@ XMLChTranscoder::transcodeFrom( const   XMLByte* const          srcData
     bytesEaten = countToDo * sizeof(XMLCh);
 
     // Set the character sizes to the fixed size
-    memset(charSizes, sizeof(XMLCh), countToDo);
+    memset(charSizes, static_cast<int>(sizeof(XMLCh)), countToDo);
 
     // Return the chars we transcoded
     return countToDo;

--- a/src/xercesc/util/XMLUTF16Transcoder.cpp
+++ b/src/xercesc/util/XMLUTF16Transcoder.cpp
@@ -111,7 +111,7 @@ XMLUTF16Transcoder::transcodeFrom(  const   XMLByte* const       srcData
     bytesEaten = countToDo * sizeof(UTF16Ch);
 
     // Set the character sizes to the fixed size
-    memset(charSizes, sizeof(UTF16Ch), countToDo);
+    memset(charSizes, static_cast<int>(sizeof(UTF16Ch)), countToDo);
 
     // Return the chars we transcoded
     return countToDo;


### PR DESCRIPTION
Fixes:
xercesc/util/XMLChTranscoder.cpp:73:23: warning: setting buffer to a 'sizeof' expression; did you mean to transpose the last two arguments? [-Wmemset-transposed-args]
    memset(charSizes, sizeof(XMLCh), countToDo);
                      ^
xercesc/util/XMLChTranscoder.cpp:73:23: note: cast the second argument to 'int' to silence

and

xercesc/util/XMLUTF16Transcoder.cpp:114:23: warning: setting buffer to a 'sizeof' expression; did you mean to transpose the last two arguments? [-Wmemset-transposed-args]
    memset(charSizes, sizeof(UTF16Ch), countToDo);
                      ^
xercesc/util/XMLUTF16Transcoder.cpp:114:23: note: cast the second argument to 'int' to silence
1 warning generated.