### PR TITLE
[XERCESC-2223] SAX2XMLReaderImpl::error(): use exception memory manager, …

### DIFF
--- a/src/xercesc/parsers/SAX2XMLReaderImpl.cpp
+++ b/src/xercesc/parsers/SAX2XMLReaderImpl.cpp
@@ -1229,7 +1229,7 @@ void SAX2XMLReaderImpl::error(  const   unsigned int
         , systemId
         , lineNum
         , colNum
-        , fMemoryManager
+        , fMemoryManager->getExceptionMemoryManager()
     );
 
     if (!fErrorHandler)


### PR DESCRIPTION
otherwise regular memory manager might fail to fully allocate the strings in the exception and cause memory leaks