### PR TITLE
XERCESC-2208: XMLSize_t size_t revert

### DIFF
--- a/src/xercesc/util/XercesDefs.hpp
+++ b/src/xercesc/util/XercesDefs.hpp
@@ -66,11 +66,6 @@
 typedef size_t                                  XMLSize_t;
 
 /**
- * Signed integer of at least 64 bits.
- */
-typedef int64_t                                 XMLSSize_t;
-
-/**
  * XML Character.  Platform-dependent 16-bit type.
  */
 typedef XERCES_XMLCH_T                          XMLCh;

--- a/src/xercesc/util/XercesDefs.hpp
+++ b/src/xercesc/util/XercesDefs.hpp
@@ -61,14 +61,14 @@
 #include    <xercesc/util/XercesVersion.hpp>
 
 /**
- * Unsigned integer of at least 64 bits.
+ * XML size type.
  */
-typedef uint64_t                                XMLSize_t;
+typedef size_t                                  XMLSize_t;
 
 /**
  * Signed integer of at least 64 bits.
  */
-typedef int64_t                                XMLSSize_t;
+typedef int64_t                                 XMLSSize_t;
 
 /**
  * XML Character.  Platform-dependent 16-bit type.


### PR DESCRIPTION
* Restore previous behaviour (XMLSize_t is size_t)
* Remove XMLSSize_t (no uses in the codebase)