### PR TITLE
[XERCESC-2235] DFAContentModel::buildDFA(): correctly zero-initialize fFollowList

### DIFF
--- a/src/xercesc/validators/common/DFAContentModel.cpp
+++ b/src/xercesc/validators/common/DFAContentModel.cpp
@@ -682,7 +682,7 @@ void DFAContentModel::buildDFA(ContentSpecNode* const curNode)
     (
         fLeafCount * sizeof(CMStateSet*)
     ); //new CMStateSet*[fLeafCount];
-    memset(fLeafList, 0, fLeafCount*sizeof(CMStateSet*));
+    memset(fFollowList, 0, fLeafCount*sizeof(CMStateSet*));
     for (index = 0; index < fLeafCount; index++)
         fFollowList[index] = new (fMemoryManager) CMStateSet(fLeafCount, fMemoryManager);
 


### PR DESCRIPTION
Due to a copy&paste issue, the intended zero-initialization of
fFollowList wasn't done (copy&paste issue), and thus in case of
OutOfMemory exception when initializing the array, the memory freeing in
cleanup() could access uninitialized elements.

Follow-up of https://github.com/apache/xerces-c/pull/40 / a65990d79d3fc333d7481f010da4e165a88b6cb3

Fixes GDAL's https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=42636