### PR TITLE
[XERCESC-2188] Fix potential double-free in usage of ReaderMgr::pushReader()

### DIFF
--- a/src/xercesc/internal/IGXMLScanner.cpp
+++ b/src/xercesc/internal/IGXMLScanner.cpp
@@ -19,6 +19,9 @@
  * $Id$
  */
 
+// SPDX-FileCopyrightText: Portions Copyright 2021 Siemens 
+// Modified on 15-Jul-2021 by Siemens and/or its affiliates to fix CVE-2018-1311: Apache Xerces-C use-after-free vulnerability scanning external DTD. Copyright 2021 Siemens.
+
 // ---------------------------------------------------------------------------
 //  Includes
 // ---------------------------------------------------------------------------
@@ -1535,13 +1538,12 @@ void IGXMLScanner::scanDocTypeDecl()
             DTDEntityDecl* declDTD = new (fMemoryManager) DTDEntityDecl(gDTDStr, false, fMemoryManager);
             declDTD->setSystemId(sysId);
             declDTD->setIsExternal(true);
-            Janitor<DTDEntityDecl> janDecl(declDTD);
 
             // Mark this one as a throw at end
             reader->setThrowAtEnd(true);
 
             // And push it onto the stack, with its pseudo name
-            fReaderMgr.pushReader(reader, declDTD);
+            fReaderMgr.pushReader(reader, declDTD, true);
 
             // Tell it its not in an include section
             dtdScanner.scanExtSubsetDecl(false, true);
@@ -3098,13 +3100,12 @@ Grammar* IGXMLScanner::loadDTDGrammar(const InputSource& src,
     DTDEntityDecl* declDTD = new (fMemoryManager) DTDEntityDecl(gDTDStr, false, fMemoryManager);
     declDTD->setSystemId(src.getSystemId());
     declDTD->setIsExternal(true);
-    Janitor<DTDEntityDecl> janDecl(declDTD);
 
     // Mark this one as a throw at end
     newReader->setThrowAtEnd(true);
 
     // And push it onto the stack, with its pseudo name
-    fReaderMgr.pushReader(newReader, declDTD);
+    fReaderMgr.pushReader(newReader, declDTD, true);
 
     //  If we have a doc type handler and advanced callbacks are enabled,
     //  call the doctype event.

--- a/src/xercesc/internal/IGXMLScanner2.cpp
+++ b/src/xercesc/internal/IGXMLScanner2.cpp
@@ -1302,7 +1302,7 @@ void IGXMLScanner::scanReset(const InputSource& src)
     }
 
     // Push this read onto the reader manager
-    fReaderMgr.pushReader(newReader, 0);
+    fReaderMgr.pushReader(newReader, 0, false);
 
     // and reset security-related things if necessary:
     if(fSecurityManager != 0)
@@ -3201,7 +3201,7 @@ IGXMLScanner::scanEntityRef(  const   bool    inAttVal
 
         //  Push the reader. If its a recursive expansion, then emit an error
         //  and return an failure.
-        if (!fReaderMgr.pushReader(reader, decl))
+        if (!fReaderMgr.pushReader(reader, decl, false))
         {
             emitError(XMLErrs::RecursiveEntity, decl->getName());
             return EntityExp_Failed;
@@ -3262,7 +3262,7 @@ IGXMLScanner::scanEntityRef(  const   bool    inAttVal
         //  where it will become the subsequent input. If it fails, that
         //  means the entity is recursive, so issue an error. The reader
         //  will have just been discarded, but we just keep going.
-        if (!fReaderMgr.pushReader(valueReader, decl))
+        if (!fReaderMgr.pushReader(valueReader, decl, false))
             emitError(XMLErrs::RecursiveEntity, decl->getName());
 
         // here's where we need to check if there's a SecurityManager,

--- a/src/xercesc/internal/SGXMLScanner.cpp
+++ b/src/xercesc/internal/SGXMLScanner.cpp
@@ -3177,7 +3177,7 @@ void SGXMLScanner::scanReset(const InputSource& src)
     }
 
     // Push this read onto the reader manager
-    fReaderMgr.pushReader(newReader, 0);
+    fReaderMgr.pushReader(newReader, 0, false);
 
     // and reset security-related things if necessary:
     if(fSecurityManager != 0)

--- a/src/xercesc/internal/WFXMLScanner.cpp
+++ b/src/xercesc/internal/WFXMLScanner.cpp
@@ -501,7 +501,7 @@ void WFXMLScanner::scanReset(const InputSource& src)
     }
 
     // Push this read onto the reader manager
-    fReaderMgr.pushReader(newReader, 0);
+    fReaderMgr.pushReader(newReader, 0, false);
 
     // and reset security-related things if necessary:
     if(fSecurityManager != 0) 

--- a/src/xercesc/internal/XSAXMLScanner.cpp
+++ b/src/xercesc/internal/XSAXMLScanner.cpp
@@ -586,7 +586,7 @@ void XSAXMLScanner::scanReset(const InputSource& src)
     }
 
     // Push this read onto the reader manager
-    fReaderMgr.pushReader(newReader, 0);
+    fReaderMgr.pushReader(newReader, 0, false);
 
     // and reset security-related things if necessary:
     if(fSecurityManager != 0)

--- a/src/xercesc/validators/DTD/DTDScanner.cpp
+++ b/src/xercesc/validators/DTD/DTDScanner.cpp
@@ -288,7 +288,7 @@ bool DTDScanner::expandPERef( const   bool    scanExternal
         //  Push the reader. If its a recursive expansion, then emit an error
         //  and return an failure.
         //
-        if (!fReaderMgr->pushReader(reader, decl))
+        if (!fReaderMgr->pushReader(reader, decl, false))
         {
             fScanner->emitError(XMLErrs::RecursiveEntity, decl->getName());
             return false;
@@ -362,7 +362,7 @@ bool DTDScanner::expandPERef( const   bool    scanExternal
         //  means the entity is recursive, so issue an error. The reader
         //  will have just been discarded, but we just keep going.
         //
-        if (!fReaderMgr->pushReader(valueReader, decl))
+        if (!fReaderMgr->pushReader(valueReader, decl, false))
             fScanner->emitError(XMLErrs::RecursiveEntity, decl->getName());
     }
 
@@ -2054,7 +2054,7 @@ DTDScanner::scanEntityRef(XMLCh& firstCh, XMLCh& secondCh, bool& escaped)
         //  Push the reader. If its a recursive expansion, then emit an error
         //  and return an failure.
         //
-        if (!fReaderMgr->pushReader(reader, decl))
+        if (!fReaderMgr->pushReader(reader, decl, false))
         {
             fScanner->emitError(XMLErrs::RecursiveEntity, decl->getName());
             return EntityExp_Failed;
@@ -2088,7 +2088,7 @@ DTDScanner::scanEntityRef(XMLCh& firstCh, XMLCh& secondCh, bool& escaped)
         //  means the entity is recursive, so issue an error. The reader
         //  will have just been discarded, but we just keep going.
         //
-        if (!fReaderMgr->pushReader(valueReader, decl))
+        if (!fReaderMgr->pushReader(valueReader, decl, false))
             fScanner->emitError(XMLErrs::RecursiveEntity, decl->getName());
     }
 


### PR DESCRIPTION
The fix consists in adding a new argument to pushReader() to specify if
ReaderMgr must own the passed entity, and adapt callers to specify the
right value of this ownership flag depending on the calling context.

SPDX-FileCopyrightText: Portions Copyright 2021 Siemens
Modified on 15-Jul-2021 by Siemens and/or its affiliates to fix CVE-2018-1311: Apache Xerces-C use-after-free vulnerability scanning external DTD. Copyright 2021 Siemens.

Co-authored-by: Even Rouault <even.rouault@spatialys.com>

Supersedes https://github.com/apache/xerces-c/pull/46 (avoids the memory leak in the unit tests)
@johnjamesmccann  Do you have access to a reproducer to confirm it fixes the issue ? I couldn't easily find a reproducer 