### PR TITLE
Mark Dependencies as `PRIVATE` in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1271,7 +1271,7 @@ set_target_properties(xerces-c-headers PROPERTIES FOLDER "Library")
 add_library(xerces-c
   ${libxerces_c_SOURCES}
   ${libxerces_c_RESOURCES})
-target_link_libraries(xerces-c ${libxerces_c_DEPS})
+target_link_libraries(xerces-c PRIVATE ${libxerces_c_DEPS})
 if(XERCES_USE_NETACCESSOR_CURL)
   target_include_directories(xerces-c SYSTEM PRIVATE ${CURL_INCLUDE_DIRS})
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,6 +112,7 @@ if(NOT XERCES_USE_MUTEXMGR_NOTHREAD)
   add_test_executable(ThreadTest
     src/ThreadTest/ThreadTest.cpp
   )
+  target_link_libraries(ThreadTest Threads::Threads)
 endif()
 
 # Fails to compile under gcc 4 (ambiguous calls to NullPointerException)


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/XERCESC-2236, where trying to use the generated CMake config package doesn't work because the dependencies are not loaded using `find_package` in the config package. This change assumes they're not necessary for users of the library and marks them as `PRIVATE` so they don't end up in the config package in the first place.