### PR TITLE
autotools: Add ws2_32 library for Windows platform

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -318,15 +318,18 @@ case $host in
 *-*-msdos* | *-*-mingw32* | *-*-cygwin* | *-*-windows* )
 	platform_export="__declspec(dllexport)"
 	platform_import="__declspec(dllimport)"
-        template_extern=""
+	platform_type_win32="yes"
+	template_extern=""
 	;;
 * )
 	platform_export=""
 	platform_import=""
-        template_extern="extern"
+	platform_type_win32="no"
+	template_extern="extern"
 	;;
 esac
 
+AM_CONDITIONAL(XERCES_PLATFORM_WIN32, test "x${platform_type_win32}" = "xyes")
 AC_DEFINE_UNQUOTED([XERCES_PLATFORM_EXPORT], [$platform_export], [Define as the platform's export attribute])
 AC_DEFINE_UNQUOTED([XERCES_PLATFORM_IMPORT], [$platform_import], [Define as the platform's import attribute])
 AC_DEFINE_UNQUOTED([XERCES_TEMPLATE_EXTERN], [$template_extern], [Define as the platform's template extern attribute])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -73,6 +73,9 @@ if XERCES_USE_NETACCESSOR_CURL
 libxerces_c_la_SOURCES += ${curl_sources}
 nobase_libxerces_c_la_HEADERS += ${curl_headers}
 AM_CPPFLAGS += ${CURL_FLAGS}
+if XERCES_PLATFORM_WIN32
+libxerces_c_la_LIBADD += -lws2_32
+endif
 endif
 
 if XERCES_USE_NETACCESSOR_SOCKET


### PR DESCRIPTION
This fixes the following linking error:

```
ld.exe: ../src/.libs/libxerces-c.a(CurlURLInputStream.o): in function 'xercesc_4_0::CurlURLInputStream::readMore(int*)':
src/xercesc/util/NetAccessors/Curl/CurlURLInputStream.cpp:370: undefined reference to '__imp_select'
```
