### PR TITLE
Fix macOS platform check when finding transcoders

### DIFF
--- a/cmake/XercesTranscoderSelection.cmake
+++ b/cmake/XercesTranscoderSelection.cmake
@@ -30,7 +30,7 @@ endif()
 # MacOS
 
 set(macosunicodeconverter_available 0)
-if(CMAKE_HOST_APPLE)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   check_include_file_cxx(CoreServices/CoreServices.h HAVE_CORESERVICES_CORESERVICES_H)
   find_library(CORE_SERVICES_LIBRARY CoreServices )
   if (HAVE_CORESERVICES_CORESERVICES_H AND CORE_SERVICES_LIBRARY)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -150,6 +150,7 @@ add_sample_executable(XInclude
 install(
   TARGETS ${sample_programs}
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  BUNDLE DESTINATION "${CMAKE_INSTALL_BINDIR}"
   COMPONENT "runtime")
 
 # Run tests


### PR DESCRIPTION
The check must verify the target platform, instead of the host. This fixes cross-compiling on macOS.

Also when targeting iOS, install(TARGET) commands require a BUNDLE destination for executables. This was missing for the samples.