### PR TITLE
The windows.h header files is with lower case

### DIFF
--- a/tests/src/ThreadTest/ThreadTest.cpp
+++ b/tests/src/ThreadTest/ThreadTest.cpp
@@ -118,7 +118,7 @@ void ThreadFuncs::startThread(ThreadFunc func, void *param)
 //
 //------------------------------------------------------------------------------
 
-#include <Windows.h>
+#include <windows.h>
 #include <process.h>
 
 typedef DWORD (WINAPI *ThreadFunc)(void *);


### PR DESCRIPTION
Contributed by STMicroelectronics