### PR TITLE
cmake: use enumerations for possible values, so that cmake-gui offersa drop-down selection

### DIFF
--- a/cmake/XercesMsgLoaderSelection.cmake
+++ b/cmake/XercesMsgLoaderSelection.cmake
@@ -42,6 +42,7 @@ endif()
 string(REPLACE ";" "|" msgloader_help "${msgloaders}")
 list(GET msgloaders 0 xerces_msgloader_default)
 set(message-loader "${xerces_msgloader_default}" CACHE STRING "Message loader (${msgloader_help})")
+set_property(CACHE message-loader PROPERTY STRINGS ${msgloaders})
 set(msgloader "${message-loader}")
 
 list(FIND msgloaders "${msgloader}" msgloader_found)

--- a/cmake/XercesMutexMgrSelection.cmake
+++ b/cmake/XercesMutexMgrSelection.cmake
@@ -90,6 +90,7 @@ list(APPEND mutexmgrs nothreads)
 string(REPLACE ";" "|" mutexmgr_help "${mutexmgrs}")
 list(GET mutexmgrs 0 xerces_mutexmgr_default)
 set(mutex-manager "${xerces_mutexmgr_default}" CACHE STRING "Mutex manager (${mutexmgr_help})")
+set_property(CACHE mutex-manager PROPERTY STRINGS ${mutexmgrs})
 set(mutexmgr "${mutex-manager}")
 
 list(FIND mutexmgrs "${mutexmgr}" mutexmgr_found)

--- a/cmake/XercesNetAccessorSelection.cmake
+++ b/cmake/XercesNetAccessorSelection.cmake
@@ -69,6 +69,7 @@ if(network)
   string(REPLACE ";" "|" netaccessor_help "${netaccessors}")
   list(GET netaccessors 0 xerces_netaccessor_default)
   set(network-accessor "${xerces_netaccessor_default}" CACHE STRING "Network accessor (${netaccessor_help})")
+  set_property(CACHE network-accessor PROPERTY STRINGS ${netaccessors})
   set(netaccessor "${network-accessor}")
 
   list(FIND netaccessors "${netaccessor}" netaccessor_found)

--- a/cmake/XercesTranscoderSelection.cmake
+++ b/cmake/XercesTranscoderSelection.cmake
@@ -87,6 +87,7 @@ endif()
 string(REPLACE ";" "|" transcoder_help "${transcoders}")
 list(GET transcoders 0 xerces_transcoder_default)
 set(transcoder "${xerces_transcoder_default}" CACHE STRING "Transcoder (${transcoder_help})")
+set_property(CACHE transcoder PROPERTY STRINGS ${transcoders})
 set(transcoder "${transcoder}")
 
 list(FIND transcoders "${transcoder}" transcoder_found)

--- a/cmake/XercesXMLCh.cmake
+++ b/cmake/XercesXMLCh.cmake
@@ -66,6 +66,7 @@ list(APPEND xmlch_types uint16_t)
 string(REPLACE ";" "|" xmlch_type_help "${xmlch_types}")
 list(GET xmlch_types 0 xerces_xmlch_type_default)
 set(xmlch-type "${xerces_xmlch_type_default}" CACHE STRING "XMLCh type (${xmlch_type_help})")
+set_property(CACHE xmlch-type PROPERTY STRINGS ${xmlch_types})
 set(xmlch_type "${xmlch-type}")
 
 list(FIND xmlch_types "${xmlch_type}" xmlch_type_found)


### PR DESCRIPTION
I have read on https://xerces.apache.org/xerces-c/source-repository.html that Jira.apache is the preferred way for submitting changesets, but it is unclear how long getting an account there will take.

The current change allows the cmake-gui (like `ccmake`) to offer the  user a fixed enumeration of possible values, so that the user can select one from a drop-down menu.  In case of `ccmake` the possible values are toggled by pressing enter and it is not anymore possible for the user to enter text as value.

I have very basic knowledge about cmake, so there might be a different way to achieve the same result.  If a different way is preferred, please go forward with it, without asking me to adopt it.