### PR TITLE
fix: NaN bypasses minInclusive/maxInclusive facets

### DIFF
--- a/src/xercesc/validators/datatype/AbstractNumericValidator.cpp
+++ b/src/xercesc/validators/datatype/AbstractNumericValidator.cpp
@@ -85,7 +85,7 @@ void AbstractNumericValidator::boundsCheck(const XMLNumber*         const theDat
     if ( (thisFacetsDefined & DatatypeValidator::FACET_MAXINCLUSIVE) != 0 )
     {
         result = compareValues(theData, getMaxInclusive());
-        if (result == 1)
+        if (result != -1 && result != 0)
         {
             REPORT_VALUE_ERROR(theData
                              , getMaxInclusive()
@@ -98,7 +98,7 @@ void AbstractNumericValidator::boundsCheck(const XMLNumber*         const theDat
     if ( (thisFacetsDefined & DatatypeValidator::FACET_MININCLUSIVE) != 0 )
     {
         result = compareValues(theData, getMinInclusive());
-        if (result == -1)
+        if (result != 1 && result != 0)
         {
             REPORT_VALUE_ERROR(theData
                              , getMinInclusive()


### PR DESCRIPTION
 NaN silently passes bounds validation due to trichotomy failure in compareValues.

**Root Cause:**
- boundsCheck assumes trichotomy from compareValues: -1, 0, or 1  
- NaN triggers compareSpecial → returns 2 (INDETERMINATE)
- Trichotomy broken by 4th value (NaN)
- minInclusive: `if (result == -1)` → misses INDETERMINATE(2)
- maxInclusive: `if (result == 1)` → misses INDETERMINATE(2)

**Affected:** minInclusive/maxInclusive facets only  
**Unaffected:** minExclusive/maxExclusive correctly detect NaN

**Fix:**
- minInclusive: reject `(result != 1 && result != 0)`
- maxInclusive: reject `(result != -1 && result != 0)`

**Jira:** [XERCESC-2263](https://issues.apache.org/jira/browse/XERCESC-2263)


According to git history this bug was introduced 23 years ago in commit:
https://github.com/apache/xerces-c/commit/f75e7f044da48772b5afff8dbfc3378d9a975ac2

What Changed:

compareSpecial() updated for Schema Errata E2-40
NaN now returns 2 (INDETERMINATE) instead of 1
What Was Missed:

boundsCheck() never updated for new return value
Still assumes trichotomy
INDETERMINATE(2) silently ignored → NaN bypasses min/maxInclusive